### PR TITLE
we should read the warnings. they are very usefull :)

### DIFF
--- a/include/answer/Operation.hh
+++ b/include/answer/Operation.hh
@@ -33,7 +33,8 @@ public:
 	OperationHandler(OperationType op, const std::string &name):Operation(name), _op(op){}
 	
 	virtual std::string invoke ( const std::string& params, const std::string& prefix){
-		std::ostringstream wrappedReponse;
+		std::ostringstream encodedReponse;
+		std::auto_ptr<WebMethodException> wrappedException;
 		try {
 			Request request;
 			
@@ -61,20 +62,21 @@ public:
 			Type &type(_methodHandle.getInstance());
 
 			Response response( (type.*_op)(request) );
-
-			std::ostringstream encodedReponse;
+			
 			if(!codec::Codec(encodedReponse, accept, response)) {
 				codec::GenericCodec(encodedReponse, response);
 			}
-			codec::ResponseWrapper<void>(wrappedReponse, encodedReponse.str(), NULL);
 		} catch (const WebMethodException &ex) {
-			codec::ResponseWrapper<void>(wrappedReponse, "", &ex);
+			wrappedException = std::auto_ptr<WebMethodException>(new WebMethodException(ex.what()));
 		} catch (const std::exception &ex) {
+			wrappedException = std::auto_ptr<WebMethodException>(new WebMethodException("Framework exception"));
 			std::cerr << "Exception: " << ex.what() << std::endl;
 		} catch (...){
 			std::cerr << "Catastrophic error, attempting to proceed" <<std::endl;
 		}
 // 		std::cerr << "Debug:" << wrappedReponse.str() << std::endl;
+		std::ostringstream wrappedReponse;
+		codec::ResponseWrapper<void>(wrappedReponse, encodedReponse.str(), wrappedException.get());
 		return wrappedReponse.str();
 	}
 };
@@ -88,7 +90,8 @@ public:
 	OperationHandler(OperationType op, const std::string &name):Operation(name), _op(op){}
 public:
 	virtual std::string invoke ( const std::string& , const std::string&){
-		std::ostringstream wrappedReponse;
+		std::ostringstream encodedReponse;
+		std::auto_ptr<WebMethodException> wrappedException;
 		try {
 			// we only look at the first accept. if it fails, we'll default to xml immediately
 			std::string accept;
@@ -101,19 +104,20 @@ public:
 			
 			Response response( (type.*_op)() );
 			
-			std::ostringstream encodedReponse;
 			if(!codec::Codec(encodedReponse, accept, response)) {
 				codec::GenericCodec(encodedReponse, response);
 			}
-			codec::ResponseWrapper<void>(wrappedReponse, encodedReponse.str(), NULL);
 		} catch (const WebMethodException &ex) {
-			codec::ResponseWrapper<void>(wrappedReponse, "", &ex);
+			wrappedException = std::auto_ptr<WebMethodException>(new WebMethodException(ex.what()));
 		} catch (const std::exception &ex) {
+			wrappedException = std::auto_ptr<WebMethodException>(new WebMethodException("Framework exception"));
 			std::cerr << "Exception: " << ex.what() << std::endl;
 		} catch (...){
 			std::cerr << "Catastrophic error, attempting to proceed" <<std::endl;
 		}
 // 		std::cerr << "Debug:" << wrappedReponse.str() << std::endl;
+		std::ostringstream wrappedReponse;
+		codec::ResponseWrapper<void>(wrappedReponse, encodedReponse.str(), wrappedException.get());
 		return wrappedReponse.str();
 	}
 };
@@ -128,7 +132,7 @@ public:
 	OperationHandler(OperationType op, const std::string &name):Operation(name), _op(op){}
 
 	virtual std::string invoke ( const std::string& params , const std::string& prefix){
-		std::ostringstream wrappedReponse;
+		std::auto_ptr<WebMethodException> wrappedException;
 		try {
 			Request request;
 			
@@ -149,15 +153,17 @@ public:
 			Type &type(_methodHandle.getInstance());
 			
 			(type.*_op)(request);
-			codec::ResponseWrapper<void>(wrappedReponse, "", NULL);
 		} catch (const WebMethodException &ex) {
-			codec::ResponseWrapper<void>(wrappedReponse, "", &ex);
+			wrappedException = std::auto_ptr<WebMethodException>(new WebMethodException(ex.what()));
 		} catch (const std::exception &ex) {
+			wrappedException = std::auto_ptr<WebMethodException>(new WebMethodException("Framework exception"));
 			std::cerr << "Exception: " << ex.what() << std::endl;
 		} catch (...){
 			std::cerr << "Catastrophic error, attempting to proceed" <<std::endl;
 		}
 // 		std::cerr << "Debug No req:" << wrappedReponse.str() << std::endl;
+		std::ostringstream wrappedReponse;
+		codec::ResponseWrapper<void>(wrappedReponse, "", wrappedException.get());
 		return wrappedReponse.str();
 	}
 };

--- a/include/answer/archive/ws_xml_iarchive.hpp
+++ b/include/answer/archive/ws_xml_iarchive.hpp
@@ -117,7 +117,7 @@ protected:
 
 		if (!m_collectionStack.empty() ){
 
-			if (t.name() == "item_version"){
+			if (itemName == "item_version"){
 				return; //Ignore item_version loading from default collection serialization implementations
 			}
 
@@ -179,7 +179,7 @@ protected:
 
 // 		std::cerr << ":(O):" << t.name() << " [" << char(is.peek()) << "] [" << int(is.tellg())<< ']' <<std::endl;
 		try{
-			this->This()->load_start(t.name(), true);
+			this->This()->load_start(itemName.c_str(), true);
 		}/*catch (boost::archive::xml_archive_exception &ex){
 			// This optional is not present
 			//  retrace the stream and proceed
@@ -198,7 +198,7 @@ protected:
 
 		is.seekg(m_lastPos );
 		boost::serialization::detail::stack_construct<ws_xml_iarchive, T> aux(*this, 0);
-		load_override(boost::serialization::make_nvp(t.name(), aux.reference()), 0);
+		load_override(boost::serialization::make_nvp(itemName.c_str(), aux.reference()), 0);
 		t.value().reset(aux.reference());
 	}
 
@@ -221,18 +221,18 @@ protected:
 	// specific overrides for attributes - not name value pairs so we
 	// want to trap them before the above "fall through"
 	// since we don't want to see these in the output - make them no-ops.
-	void load_override(boost::archive::object_id_type & t, int){}
-	void load_override(boost::archive::object_reference_type & t, int){}
-	void load_override(boost::archive::version_type & t, int){}
-	void load_override(boost::archive::class_id_type & t, int){}
-	void load_override(boost::archive::class_id_optional_type & t, int){}
-	void load_override(boost::archive::class_id_reference_type & t, int){}
-	void load_override(boost::archive::class_name_type & t, int){}
-	void load_override(boost::archive::tracking_type & t, int){}
+	void load_override(boost::archive::object_id_type &, int){}
+	void load_override(boost::archive::object_reference_type &, int){}
+	void load_override(boost::archive::version_type &, int){}
+	void load_override(boost::archive::class_id_type &, int){}
+	void load_override(boost::archive::class_id_optional_type &, int){}
+	void load_override(boost::archive::class_id_reference_type &, int){}
+	void load_override(boost::archive::class_name_type &, int){}
+	void load_override(boost::archive::tracking_type &, int){}
 
 public:
-	ws_xml_iarchive(std::istream & is, unsigned int flags = 0) :
-		xml_iarchive_impl<ws_xml_iarchive>(is, flags| boost::archive::no_header )
+	ws_xml_iarchive(std::istream & is_, unsigned int flags = 0) :
+		xml_iarchive_impl<ws_xml_iarchive>(is_, flags| boost::archive::no_header )
 	{}
 	~ws_xml_iarchive(){}
 };

--- a/include/answer/archive/ws_xml_oarchive.hpp
+++ b/include/answer/archive/ws_xml_oarchive.hpp
@@ -104,19 +104,19 @@ class ws_xml_oarchive :
     // specific overrides for attributes - not name value pairs so we
     // want to trap them before the above "fall through"
     // since we don't want to see these in the output - make them no-ops.
-    void save_override(const boost::archive::object_id_type & t, int){}
-    void save_override(const boost::archive::object_reference_type & t, int){}
-    void save_override(const boost::archive::version_type & t, int){}
-    void save_override(const boost::archive::class_id_type & t, int){}
-    void save_override(const boost::archive::class_id_optional_type & t, int){}
-    void save_override(const boost::archive::class_id_reference_type & t, int){}
-    void save_override(const boost::archive::class_name_type & t, int){}
-    void save_override(const boost::archive::tracking_type & t, int){}
+    void save_override(const boost::archive::object_id_type &, int){}
+    void save_override(const boost::archive::object_reference_type &, int){}
+    void save_override(const boost::archive::version_type &, int){}
+    void save_override(const boost::archive::class_id_type &, int){}
+    void save_override(const boost::archive::class_id_optional_type &, int){}
+    void save_override(const boost::archive::class_id_reference_type &, int){}
+    void save_override(const boost::archive::class_name_type &, int){}
+    void save_override(const boost::archive::tracking_type &, int){}
     
 public:
-    ws_xml_oarchive(std::ostream & os, unsigned int flags = 0) :
+    ws_xml_oarchive(std::ostream & os_, unsigned int flags = 0) :
         boost::archive::xml_oarchive_impl<ws_xml_oarchive>(
-            os, 
+            os_, 
             flags | boost::archive::no_header
         )
     {}


### PR DESCRIPTION
- removed warnings
- removed shadow variables
- safer use of compare for certain compiler versions (optimization related)
